### PR TITLE
Refactor how global config methods are exposed to tasks.

### DIFF
--- a/lib/harrison/base.rb
+++ b/lib/harrison/base.rb
@@ -23,12 +23,10 @@ module Harrison
       end
     end
 
-    # Find config from Harrison.config if it's not on this class.
-    def method_missing(meth, *args, &block)
-      if Harrison.config.respond_to?(meth)
-        Harrison.config.send(meth, *args, &block)
-      else
-        super
+    # Add config getter methods from Harrison.config to this class.
+    Harrison::Config.config_keys.each do |key|
+      define_method(key) do
+        Harrison.config.send(key)
       end
     end
 

--- a/lib/harrison/config.rb
+++ b/lib/harrison/config.rb
@@ -1,9 +1,16 @@
 module Harrison
   class Config
-    attr_accessor :project
-    attr_accessor :git_src
-
     def initialize(opts={})
+      self.class.config_keys.each do |key|
+        self.class.send(:attr_accessor, key)
+      end
+    end
+
+    def self.config_keys
+      [
+        :project,
+        :git_src,
+      ]
     end
   end
 end

--- a/spec/unit/harrison/deploy_spec.rb
+++ b/spec/unit/harrison/deploy_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe Harrison::Deploy do
+  before(:all) do
+    Harrison.class_variable_set(:@@config, Harrison::Config.new)
+    Harrison.config.project = 'test_project'
+  end
+
   let(:instance) do
     Harrison::Deploy.new.tap do |d|
       d.hosts = [ 'hf_host' ]
@@ -71,7 +76,6 @@ describe Harrison::Deploy do
     describe '#remote_exec' do
       before(:each) do
         instance.base_dir = '/opt'
-        instance.project = 'test_project'
 
         @mock_ssh = double(:ssh)
         expect(instance).to receive(:ssh).and_return(@mock_ssh)
@@ -157,7 +161,6 @@ describe Harrison::Deploy do
     describe '#run' do
       before(:each) do
         instance.artifact = 'test_artifact.tar.gz'
-        instance.project = 'test_project'
 
         @mock_ssh = double(:ssh, host: 'test_host1', exec: '', upload: true, download: true)
         allow(instance).to receive(:ssh).and_return(@mock_ssh)
@@ -253,8 +256,6 @@ describe Harrison::Deploy do
       context 'when invoked via rollback' do
         before(:each) do
           instance.rollback = true
-
-          instance.project = 'test_project'
 
           @mock_ssh = double(:ssh, host: 'test_host1', exec: '', upload: true, download: true)
           allow(instance).to receive(:ssh).and_return(@mock_ssh)
@@ -389,7 +390,6 @@ describe Harrison::Deploy do
     describe '#remote_project_dir' do
       it 'should combine base_dir and project name' do
         instance.base_dir = '/test_base_dir'
-        instance.project = 'test_project'
 
         expect(instance.send(:remote_project_dir)).to include('/test_base_dir', 'test_project')
       end

--- a/spec/unit/harrison/package_spec.rb
+++ b/spec/unit/harrison/package_spec.rb
@@ -1,9 +1,13 @@
 require 'spec_helper'
 
 describe Harrison::Package do
+  before(:all) do
+    Harrison.class_variable_set(:@@config, Harrison::Config.new)
+    Harrison.config.project = 'test_project'
+  end
+
   let(:instance) do
     Harrison::Package.new.tap do |p|
-      p.project = 'test_project'
       p.host = 'hf_host'
       p.commit = 'HEAD'
     end
@@ -43,7 +47,6 @@ describe Harrison::Package do
 
       it 'should prepend remote build dir onto passed command' do
         instance.remote_dir = '~/.harrison'
-        instance.project = 'test_project'
 
         expect(@mock_ssh).to receive(:exec).with("cd ~/.harrison/test_project/package && test_command").and_return('')
 
@@ -89,7 +92,6 @@ describe Harrison::Package do
     describe '#remote_project_dir' do
       it 'should combine remote dir and project name' do
         instance.remote_dir = '~/.harrison'
-        instance.project = 'test_project'
 
         expect(instance.send(:remote_project_dir)).to include('~/.harrison', 'test_project')
       end


### PR DESCRIPTION
Resolves #22 by making global config essentially immutable from inside
task configs.