### PR TITLE
(PF-2539) Update dependencies to resolve Ruby 2.7 deprecation warnings

### DIFF
--- a/.github/workflows/ruby-spec.yml
+++ b/.github/workflows/ruby-spec.yml
@@ -1,0 +1,30 @@
+name: ruby-rspec
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Test with Ruby ${{ matrix.ruby_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [2.7, 2.6]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Build and test with Rspec
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+          bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 .bundle
 .config
 .yardoc
-Gemfile.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: ruby
-rvm:
-  - ruby-head
-  - 2.1.1
-  - 2.0.0
-  - 1.9.3

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.9.2
+-------------------
+- Bumped dependencies on highline and bundler to latest majors
+
 0.9.1
 -------------------
 - Bumped dependencies on net-ssh and net-scp to latest majors

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,79 @@
+PATH
+  remote: .
+  specs:
+    harrison (0.9.1)
+      highline (~> 2.0.3)
+      net-scp (~> 3.0)
+      net-ssh (~> 6.1)
+      trollop (~> 2.1.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (11.1.3)
+    coderay (1.1.3)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    file-tail (1.2.0)
+      tins (~> 1.0)
+    highline (2.0.3)
+    method_source (1.0.0)
+    net-scp (3.0.0)
+      net-ssh (>= 2.6.5, < 7.0.0)
+    net-ssh (6.1.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    rake (13.0.6)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    ruby2ruby (2.4.4)
+      ruby_parser (~> 3.1)
+      sexp_processor (~> 4.6)
+    ruby_parser (3.18.1)
+      sexp_processor (~> 4.16)
+    sexp_processor (4.16.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    sourcify (0.5.0)
+      file-tail (>= 1.0.5)
+      ruby2ruby (>= 1.2.5)
+      ruby_parser (>= 2.0.5)
+      sexp_processor (>= 3.0.5)
+    sync (0.5.0)
+    tins (1.31.0)
+      sync
+    trollop (2.1.3)
+
+PLATFORMS
+  x86_64-darwin-18
+
+DEPENDENCIES
+  bundler (~> 2.3)
+  harrison!
+  pry-byebug
+  rake
+  rspec (~> 3.0)
+  simplecov
+  sourcify
+
+BUNDLED WITH
+   2.3.6

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Simple artifact-based deployment for web applications.
 
-[![Build Status](https://travis-ci.org/puppetlabs/harrison.svg?branch=master)](https://travis-ci.org/puppetlabs/harrison)
-
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/harrison.gemspec
+++ b/harrison.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "trollop", "~> 2.1.2"
   spec.add_runtime_dependency "net-ssh", "~> 6.1"
   spec.add_runtime_dependency "net-scp", "~> 3.0"
-  spec.add_runtime_dependency "highline", "~> 1.7.8"
+  spec.add_runtime_dependency "highline", "~> 2.0.3"
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 2.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov"

--- a/lib/harrison/version.rb
+++ b/lib/harrison/version.rb
@@ -1,3 +1,3 @@
 module Harrison
-  VERSION = "0.9.1"
+  VERSION = "0.9.2"
 end


### PR DESCRIPTION
Tested this locally with the package & deploy steps, and the deprecation warnings from highline were no longer present.