### PR TITLE
(MAINT) Update Gemfile.lock with current gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    harrison (0.9.1)
+    harrison (0.9.2)
       highline (~> 2.0.3)
       net-scp (~> 3.0)
       net-ssh (~> 6.1)
@@ -76,4 +76,4 @@ DEPENDENCIES
   sourcify
 
 BUNDLED WITH
-   2.3.6
+   2.3.7


### PR DESCRIPTION
@scotje it seems like I've maybe gotten into a weird state with the release process, where I think that Gemfile.lock was updated as a part of me running `bundle exec rake release`, which I did after creating a signed tag. Is it possible that `rake release` predates the recommendation to commit Gemfile.lock? If it seems like adding it creates unnecessary complication, I can open a PR to remove it.

My follow-up question then is whether I need to create a new tag? 😓  It looks like `rake release` will automatically create a new tag, but I'm not sure if it will be signed.