### PR TITLE
Force docker platform to amd64 when on M1 Mac

### DIFF
--- a/lib/harrison/package.rb
+++ b/lib/harrison/package.rb
@@ -182,6 +182,7 @@ module Harrison
 
           docker_build_argv = [
             'docker', 'build',
+            '--platform', 'linux/amd64',
             '--file', df,
             '--tag', docker_image_tag,
             '.',
@@ -202,6 +203,7 @@ module Harrison
 
           docker_run_argv = [
             "docker", "run",
+            "--platform", "linux/amd64",
             "--mount", "type=bind,source=#{tmp_src_dir},target=/src,readonly",
             "--mount", "type=bind,source=\"$(pwd)/pkg\",target=/pkg",
             docker_image_tag,


### PR DESCRIPTION
This PR adds an argument to Docker build and run commands to explicitly specify the platform amd64. This is needed when using Harrison on an M1 Mac.
A better solution could be to introduce a config parameter so this is not hard-wired but configurable by the user.