### PR TITLE
release prep 0.9.3

### DIFF
--- a/lib/harrison/version.rb
+++ b/lib/harrison/version.rb
@@ -1,3 +1,3 @@
 module Harrison
-  VERSION = "0.9.2"
+  VERSION = "0.9.3"
 end


### PR DESCRIPTION
- Force docker platform to amd64 when on M1 Mac
- bump gem version
