### PR TITLE
Adding linux platform support for gemfile.lock and bumping harrison to 0.9.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,6 @@ GEM
     trollop (2.1.3)
 
 PLATFORMS
-   ruby
    x86_64-darwin-18
    x86_64-linux
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,8 +64,9 @@ GEM
     trollop (2.1.3)
 
 PLATFORMS
-   x86_64-darwin-18
-   x86_64-linux
+  arm64-darwin-22
+  x86_64-darwin-18
+  x86_64-linux
 
 DEPENDENCIES
   bundler (~> 2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-18
+  x86_64-linux
 
 DEPENDENCIES
   bundler (~> 2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    harrison (0.9.2)
+    harrison (0.9.3)
       highline (~> 2.0.3)
       net-scp (~> 3.0)
       net-ssh (~> 6.1)
@@ -64,8 +64,9 @@ GEM
     trollop (2.1.3)
 
 PLATFORMS
-  x86_64-darwin-18
-  x86_64-linux
+   ruby
+   x86_64-darwin-18
+   x86_64-linux
 
 DEPENDENCIES
   bundler (~> 2.3)


### PR DESCRIPTION
## Summary
Adding linux platform support for gemfile.lock and bumping harrison to 0.9.3

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.