### PR TITLE
Update event

### DIFF
--- a/.github/workflows/labeller.yml
+++ b/.github/workflows/labeller.yml
@@ -6,7 +6,7 @@ on:
       - opened
       - labeled
       - unlabeled
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - labeled


### PR DESCRIPTION
We've found that the `pull_request_target` event is needed for this workflow. Its usage is safe.
